### PR TITLE
import nixvim.homeManagerModules.nixvim

### DIFF
--- a/home-manager/profiles/common.nix
+++ b/home-manager/profiles/common.nix
@@ -10,6 +10,8 @@ with lib; {
   imports = with flake-self.homeManagerModules; [
     neovim
     zsh
+  ] ++ [
+    flake-self.inputs.nixvim.homeManagerModules.nixvim
   ];
   config = {
     home.sessionVariables = {


### PR DESCRIPTION
This might help :)

See: https://github.com/nix-community/nixvim#using-flakes

> You can now access the module using inputs.nixvim.homeManagerModules.nixvim, for a home-manager installation, inputs.nixvim.nixosModules.nixvim, for NixOS, and inputs.nixvim.nixDarwinModules.nixvim for nix-darwin.