### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0"
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   lockfile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ALinkbetweenNets/nix/security/code-scanning/1](https://github.com/ALinkbetweenNets/nix/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's actions, it primarily interacts with repository contents (e.g., checking out the repository and updating the `flake.lock` file). Therefore, the `contents: write` permission is necessary. Other permissions, such as `pull-requests: write`, may also be required if the `DeterminateSystems/update-flake-lock` action creates or updates pull requests.

The `permissions` block will be added at the root of the workflow file, ensuring it applies to all jobs unless overridden by job-specific `permissions`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
