### PR TITLE
remove redundant ".pkgs" to avoid confusing readers

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,4 @@
 inputs: self: super: {
   # our packages are accessible via link.<name>
-  link = { candy-icon-theme = super.pkgs.callPackage ./candy-icon-theme { }; };
+  link = { candy-icon-theme = super.callPackage ./candy-icon-theme { }; };
 }


### PR DESCRIPTION
it took me several minutes of staring at this line in confusion until i realized that [nixpkgs.pkgs == nixpkgs](https://stackoverflow.com/questions/33233675/nix-whats-the-concrete-difference-between-nixpkgs-and-nixpkgs-pkgs)

give
```sh
nix run nixpkgs#pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.pkgs.hello
```
a try :)